### PR TITLE
Show only studied words in quiz mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ function _getRandomWords(level: string, count = 10): Word[] {
 }
 
 // Function to get all words from all levels (for quiz options)
-function getAllWords(): Word[] {
+function _getAllWords(): Word[] {
     if (!vocabulary) return [];
     const allWords: Word[] = [];
     Object.values(vocabulary).forEach((levelWords) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -539,7 +539,7 @@ class ArmenianLearningApp {
     }
 
     generateQuizOptions(correctWord: Word): Word[] {
-        const allWords = getAllWords();
+        const allWords = this.learningWords;
         const options: Word[] = [correctWord];
 
         // Add random incorrect options


### PR DESCRIPTION
Modify quiz mode so answer options only include words from the current learning session, not all vocabulary. This ensures quiz options only contain words the user just studied, making the quiz more focused and pedagogically effective.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses quiz options on studied content.
> 
> - Quiz answer choices are now generated from `this.learningWords` (current session) instead of all vocabulary
> - Internal cleanup: `getAllWords` renamed to `_getAllWords` and no longer used in `generateQuizOptions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 166e2adb5402d44d70dbec30f5babfa73142aa9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->