### PR TITLE
Refactor quiz to be translation-based

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "module",
     "packageManager": "bun@latest",
     "scripts": {
-        "dev": "vite dev",
-        "build": "vite build",
-        "preview": "vite preview",
+        "dev": "bunx --bun vite dev",
+        "build": "bunx --bun vite build",
+        "preview": "bunx --bun vite preview",
         "prepare": "svelte-kit sync || echo ''",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,4 +1,4 @@
-export { learntWords, userStats } from './progress.js';
+export { learntTranslations, learntWords, userStats } from './progress.js';
 export {
     createQuizQuestions,
     currentLevel,
@@ -6,6 +6,7 @@ export {
     currentWordIndex,
     generateQuizOptions,
     learningWords,
+    quizQuestions,
     quizScore,
     quizWords,
     resetLearningSession,

--- a/src/lib/stores/progress.ts
+++ b/src/lib/stores/progress.ts
@@ -1,6 +1,6 @@
 import { get, writable } from 'svelte/store';
 import { browser } from '$app/environment';
-import type { LevelStats, UserStats, Word } from '$lib/types.js';
+import type { QuizQuestion, UserStats, Word } from '$lib/types.js';
 
 const STORAGE_PREFIX = 'armenianApp_';
 
@@ -39,7 +39,134 @@ function createUserStatsStore() {
     };
 }
 
-// Learnt words store - stored as comma-separated string for backwards compatibility
+/**
+ * Creates a unique key for a translation.
+ * Format: "armenianWord|translation" (e.g., "է|is")
+ */
+function createTranslationKey(word: Word, translation: string): string {
+    return `${word.am}|${translation}`;
+}
+
+/**
+ * Migrates old learntWords (word-based) to learntTranslations (translation-based).
+ * For each learned word, marks ALL its translations as learned.
+ */
+function migrateFromLearntWords(vocabulary: Record<string, Word[]>): string[] {
+    const oldKey = `${STORAGE_PREFIX}learntWords`;
+    const stored = browser ? localStorage.getItem(oldKey) : null;
+
+    if (!stored) {
+        return [];
+    }
+
+    const learnedWordIds = stored
+        .split(',')
+        .map((w) => w.trim())
+        .filter(Boolean);
+
+    if (learnedWordIds.length === 0) {
+        return [];
+    }
+
+    // Build a map of armenian word -> Word object
+    const wordMap = new Map<string, Word>();
+    for (const level of Object.values(vocabulary)) {
+        for (const word of level) {
+            wordMap.set(word.am, word);
+        }
+    }
+
+    // Convert learned words to learned translations
+    const learntTranslations: string[] = [];
+    for (const wordId of learnedWordIds) {
+        const word = wordMap.get(wordId);
+        if (word) {
+            // Mark all translations of this word as learned
+            for (const translation of word.en) {
+                learntTranslations.push(createTranslationKey(word, translation));
+            }
+            for (const translation of word.ru) {
+                learntTranslations.push(createTranslationKey(word, translation));
+            }
+        }
+    }
+
+    // Remove old key after migration
+    if (browser) {
+        localStorage.removeItem(oldKey);
+    }
+
+    return learntTranslations;
+}
+
+// Learnt translations store - tracks individual translations that have been learned
+function createLearntTranslationsStore() {
+    const key = `${STORAGE_PREFIX}learntTranslations`;
+    const stored = browser ? localStorage.getItem(key) : null;
+    const data = stored
+        ? stored
+              .split(',')
+              .map((w) => w.trim())
+              .filter(Boolean)
+        : [];
+    const store = writable<string[]>(data);
+
+    if (browser) {
+        store.subscribe((value) => {
+            localStorage.setItem(key, value.join(','));
+        });
+    }
+
+    return {
+        subscribe: store.subscribe,
+        /**
+         * Marks a specific translation as learned.
+         */
+        markAsLearnt: (question: QuizQuestion) => {
+            const translationKey = createTranslationKey(question.word, question.translation);
+            store.update((translations) => {
+                if (!translations.includes(translationKey)) {
+                    return [...translations, translationKey];
+                }
+                return translations;
+            });
+        },
+        /**
+         * Checks if a specific translation has been learned.
+         */
+        isLearnt: (word: Word, translation: string): boolean => {
+            const translationKey = createTranslationKey(word, translation);
+            return get(store).includes(translationKey);
+        },
+        /**
+         * Runs migration from old learntWords format if needed.
+         * Should be called once when vocabulary is loaded.
+         */
+        migrateIfNeeded: (vocabulary: Record<string, Word[]>) => {
+            const oldKey = `${STORAGE_PREFIX}learntWords`;
+            const hasOldData = browser && localStorage.getItem(oldKey);
+
+            if (hasOldData) {
+                const migratedTranslations = migrateFromLearntWords(vocabulary);
+                if (migratedTranslations.length > 0) {
+                    store.update((existing) => {
+                        const combined = [...existing, ...migratedTranslations];
+                        // Remove duplicates
+                        return [...new Set(combined)];
+                    });
+                }
+            }
+        },
+        reset: () => {
+            store.set([]);
+            if (browser) {
+                localStorage.removeItem(key);
+            }
+        },
+    };
+}
+
+/** @deprecated Use learntTranslations instead */
 function createLearntWordsStore() {
     const key = `${STORAGE_PREFIX}learntWords`;
     const stored = browser ? localStorage.getItem(key) : null;
@@ -80,4 +207,6 @@ function createLearntWordsStore() {
 }
 
 export const userStats = createUserStatsStore();
+export const learntTranslations = createLearntTranslationsStore();
+/** @deprecated Use learntTranslations instead */
 export const learntWords = createLearntWordsStore();

--- a/src/lib/stores/quiz.ts
+++ b/src/lib/stores/quiz.ts
@@ -1,5 +1,17 @@
-import { get, writable } from 'svelte/store';
-import type { QuizWord, Word } from '$lib/types.js';
+import { writable } from 'svelte/store';
+import type { QuizLanguage, QuizQuestion, QuizWord, Word } from '$lib/types.js';
+
+/**
+ * Fisher-Yates shuffle for unbiased randomization.
+ * Mutates the array in place and returns it.
+ */
+function shuffle<T>(array: T[]): T[] {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
 
 // Session state - not persisted to localStorage
 export const currentLevel = writable<string | null>(null);
@@ -7,15 +19,19 @@ export const learningWords = writable<Word[]>([]);
 export const currentWordIndex = writable<number>(0);
 
 // Quiz state
-export const quizWords = writable<QuizWord[]>([]);
+export const quizQuestions = writable<QuizQuestion[]>([]);
 export const currentQuizIndex = writable<number>(0);
 export const quizScore = writable<number>(0);
+
+/** @deprecated Use quizQuestions instead */
+export const quizWords = writable<QuizWord[]>([]);
 
 export function resetLearningSession() {
     currentWordIndex.set(0);
 }
 
 export function resetQuizSession() {
+    quizQuestions.set([]);
     quizWords.set([]);
     currentQuizIndex.set(0);
     quizScore.set(0);
@@ -32,13 +48,30 @@ export function generateQuizOptions(correctWord: Word, allWords: Word[]): Word[]
         }
     }
 
-    // Shuffle options
-    return options.sort(() => 0.5 - Math.random());
+    return shuffle(options);
 }
 
-export function createQuizQuestions(words: Word[]): QuizWord[] {
-    return words.map((word) => ({
-        ...word,
-        options: generateQuizOptions(word, words),
-    }));
+/**
+ * Creates translation-based quiz questions.
+ * Each translation of a word becomes a separate question.
+ * For example, if a word has 3 English translations, it creates 3 questions.
+ */
+export function createQuizQuestions(words: Word[], language: QuizLanguage): QuizQuestion[] {
+    const questions: QuizQuestion[] = [];
+
+    for (const word of words) {
+        const translations = language === 'english' ? word.en : word.ru;
+
+        // Create a question for each translation
+        for (const translation of translations) {
+            questions.push({
+                word,
+                translation,
+                options: generateQuizOptions(word, words),
+            });
+        }
+    }
+
+    // Shuffle questions so same word's translations aren't consecutive
+    return shuffle(questions);
 }

--- a/src/lib/stores/vocabulary.ts
+++ b/src/lib/stores/vocabulary.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { Vocabulary, Word } from '$lib/types.js';
+import { learntTranslations } from './progress.js';
 
 function createVocabularyStore() {
     const store = writable<Vocabulary | null>(null);
@@ -21,6 +22,9 @@ function createVocabularyStore() {
                 }
                 const data = (await response.json()) as Vocabulary;
                 store.set(data);
+
+                // Run migration from old learntWords format if needed
+                learntTranslations.migrateIfNeeded(data);
             } catch (error) {
                 console.error('Error loading vocabulary:', error);
                 throw error;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,8 +19,15 @@ export interface UserStats {
     [level: string]: LevelStats;
 }
 
+/** @deprecated Use QuizQuestion instead */
 export interface QuizWord extends Word {
     options: Word[];
+}
+
+export interface QuizQuestion {
+    word: Word; // The original word being tested
+    translation: string; // The specific translation being tested
+    options: Word[]; // Answer options (Armenian words to choose from)
 }
 
 export type QuizLanguage = 'english' | 'russian';

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import { get } from 'svelte/store';
 import { goto } from '$app/navigation';
 import { trackQuizComplete } from '$lib/analytics.js';
-import { ProgressBar, QuizOption } from '$lib/components/index.js';
+import { QuizOption } from '$lib/components/index.js';
 import {
     cardsCount,
     createQuizQuestions,
     currentLevel,
     currentQuizIndex,
     learningWords,
-    learntWords,
+    learntTranslations,
     quizLanguage,
+    quizQuestions,
     quizScore,
-    quizWords,
     resetQuizSession,
     userStats,
 } from '$lib/stores/index.js';
-import type { QuizLanguage, QuizWord, Word } from '$lib/types.js';
+import type { QuizLanguage, QuizQuestion, Word } from '$lib/types.js';
 
 let words = $state<Word[]>([]);
-let questions = $state<QuizWord[]>([]);
+let questions = $state<QuizQuestion[]>([]);
 let questionIndex = $state(0);
 let score = $state(0);
 let level = $state<string | null>(null);
@@ -30,6 +31,10 @@ let answered = $state(false);
 let showComplete = $state(false);
 
 onMount(() => {
+    // Get language first (needed for creating questions)
+    const currentLanguage = get(quizLanguage);
+    language = currentLanguage;
+
     // Check if we have learning words
     const unsubLearning = learningWords.subscribe((w) => {
         words = w;
@@ -37,10 +42,10 @@ onMount(() => {
             goto('/');
             return;
         }
-        // Create quiz questions
-        const qs = createQuizQuestions(w);
+        // Create translation-based quiz questions
+        const qs = createQuizQuestions(w, language);
         questions = qs;
-        quizWords.set(qs);
+        quizQuestions.set(qs);
         resetQuizSession();
     });
 
@@ -68,16 +73,6 @@ onMount(() => {
 const currentQuestion = $derived(questions[questionIndex]);
 const displayIndex = $derived(questionIndex + 1);
 
-const translationQuestion = $derived(() => {
-    if (!currentQuestion) return '';
-    const data = language === 'english' ? currentQuestion.en : currentQuestion.ru;
-    if (Array.isArray(data) && data.length > 0) {
-        // Pick a random translation for the quiz
-        return data[Math.floor(Math.random() * data.length)];
-    }
-    return '';
-});
-
 const percentage = $derived(
     questions.length > 0 ? Math.round((score / questions.length) * 100) : 0
 );
@@ -88,10 +83,10 @@ function selectOption(option: Word) {
     selectedOption = option;
     answered = true;
 
-    const isCorrect = option.am === currentQuestion.am;
+    const isCorrect = option.am === currentQuestion.word.am;
     if (isCorrect) {
         quizScore.update((s) => s + 1);
-        learntWords.markAsLearnt(currentQuestion);
+        learntTranslations.markAsLearnt(currentQuestion);
     }
 
     // Auto-advance after 1 second
@@ -123,7 +118,7 @@ function handleQuizComplete() {
     })();
 
     let learntCount = 0;
-    learntWords.subscribe((w) => (learntCount = w.length))();
+    learntTranslations.subscribe((t) => (learntCount = t.length))();
 
     trackQuizComplete(level, progressByLevel, learntCount, language, count);
 }
@@ -155,13 +150,13 @@ function changeLevel() {
 		<div class="quiz-card">
 			<div class="quiz-question">
 				<p>Select the Armenian word for:</p>
-				<div class="translation-question" id="translation-question">{translationQuestion()}</div>
+				<div class="translation-question" id="translation-question">{currentQuestion.translation}</div>
 			</div>
 			<div class="options" id="quiz-options">
 				{#each currentQuestion.options as option}
 					<QuizOption
 						word={option}
-						isCorrect={option.am === currentQuestion.am}
+						isCorrect={option.am === currentQuestion.word.am}
 						isSelected={selectedOption?.am === option.am}
 						disabled={answered}
 						onclick={() => selectOption(option)}


### PR DESCRIPTION
## Summary
- Refactor quiz system to be translation-based (each translation becomes a separate question)
- Add silent migration from old `learntWords` localStorage to new `learntTranslations` format
- Use Fisher-Yates shuffle for proper randomization
- Fix vite scripts to use bun runtime

## Changes
- Add `QuizQuestion` type that pairs a word with a specific translation
- Add `learntTranslations` store to track individual translations learned
- Update quiz page to use new translation-based questions
- Fix `package.json` scripts to use `bunx --bun` for vite commands

## Test plan
- [ ] Start learning mode with a level
- [ ] Complete learning and start quiz
- [ ] Verify quiz has more questions than words (if words have multiple translations)
- [ ] Verify questions are properly randomized
- [ ] Verify correct answers are tracked
- [ ] Test migration: set old `armenianApp_learntWords` in localStorage, reload, verify migration to `armenianApp_learntTranslations`