### PR TITLE
Fix GitHub Pages deployment base path (Vibe Kanban)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build application
         run: bun run build
+        env:
+          NODE_ENV: production
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
 			strict: false
 		}),
 		paths: {
-			base: ''
+			base: process.env.NODE_ENV === 'production' ? '/armenian-words' : ''
 		},
 		prerender: {
 			handleUnseenRoutes: 'ignore'


### PR DESCRIPTION
## Summary

Fixes 404 errors when loading the app from GitHub Pages. Assets were being requested from the root path (`/_app/...`) instead of the repository subdirectory (`/armenian-words/_app/...`).

## Changes

### `svelte.config.js`
- Set `paths.base` to `/armenian-words` when `NODE_ENV=production`
- Keeps base path empty for local development to avoid path issues

### `.github/workflows/deploy.yml`
- Added `NODE_ENV: production` environment variable to the build step
- This triggers SvelteKit to use the correct base path for GitHub Pages

## Why

When deploying a SvelteKit app to GitHub Pages as a project site (not a user/org site), the app is served from a subdirectory (`username.github.io/repo-name`). SvelteKit needs to know this base path to generate correct URLs for:
- JavaScript chunks (`/_app/immutable/...`)
- CSS files
- Other static assets

Without the correct base path, the browser requests assets from the root domain, resulting in 404 errors.

## Testing

- [x] Local development still works with `bun run dev`
- [x] Production build generates correct asset paths
- [x] GitHub Pages deployment serves assets correctly

---

This PR was written using [Vibe Kanban](https://vibekanban.com)