### PR TITLE
Fix vocabulary.json fetch to use base path (Vibe Kanban)

### DIFF
--- a/src/lib/stores/vocabulary.ts
+++ b/src/lib/stores/vocabulary.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
+import { base } from '$app/paths';
 import type { Vocabulary, Word } from '$lib/types.js';
 import { learntTranslations } from './progress.js';
 
@@ -14,7 +15,7 @@ function createVocabularyStore() {
             loading = true;
 
             try {
-                const response = await fetch('/vocabulary.json');
+                const response = await fetch(`${base}/vocabulary.json`);
                 if (!response.ok) {
                     throw new Error(
                         `Failed to load vocabulary: ${response.status} ${response.statusText}`


### PR DESCRIPTION
## Summary

Fixes the vocabulary.json fetch to use SvelteKit's base path, ensuring it loads correctly on GitHub Pages.

## Problem

After the previous deployment fix (PR #6), JavaScript assets loaded correctly but `vocabulary.json` was still being fetched from the root path (`/vocabulary.json`) instead of the subdirectory path (`/armenian-words/vocabulary.json`).

## Solution

Import `base` from `$app/paths` and use it in the fetch URL:

```typescript
import { base } from '$app/paths';
// ...
const response = await fetch(`${base}/vocabulary.json`);
```

## Why this wasn't caught before

Static assets referenced in HTML/CSS are handled by SvelteKit's build process, but dynamic `fetch()` calls in JavaScript need to manually use the `base` path.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)