### PR TITLE
Add "etymology_text" and "pos" to words descriptions

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -351,6 +351,27 @@ header p {
     line-height: 1.5;
 }
 
+.part-of-speech {
+    font-size: 0.95rem;
+    color: #667eea;
+    font-style: italic;
+    margin-bottom: 0.5rem;
+    text-transform: lowercase;
+}
+
+.etymology {
+    font-size: 0.95rem;
+    color: #718096;
+    font-style: italic;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    background: #f7fafc;
+    border-radius: 8px;
+    border-left: 3px solid #667eea;
+    line-height: 1.5;
+}
+
 .quiz-card {
     padding: 2rem;
 }
@@ -794,6 +815,15 @@ footer .link-button:hover {
     }
 }
 
+.detail-part-of-speech {
+    text-align: center;
+    font-size: 1rem;
+    color: #667eea;
+    font-style: italic;
+    margin-bottom: 0.5rem;
+    text-transform: lowercase;
+}
+
 .detail-pronunciation {
     text-align: center;
     font-size: 1.25rem;
@@ -801,6 +831,18 @@ footer .link-button:hover {
     font-style: italic;
     font-weight: 500;
     margin-bottom: 2rem;
+}
+
+.detail-etymology {
+    font-size: 1rem;
+    color: #718096;
+    font-style: italic;
+    margin-top: 2rem;
+    padding: 1rem 1.25rem;
+    background: white;
+    border-radius: 8px;
+    border-left: 3px solid #667eea;
+    line-height: 1.6;
 }
 
 .translations-section {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,8 @@ export interface Word {
     ru: string[];
     en: string[];
     spell?: string;
+    pos?: string;
+    etymology_text?: string;
     ogg_url?: string;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,3 +60,32 @@ export function playSound(url: string | undefined): void {
         // Silently ignore playback errors (autoplay restrictions, network issues)
     });
 }
+
+/**
+ * Part of speech abbreviation mappings for English and Russian.
+ */
+const posLabels: Record<string, { english: string; russian: string }> = {
+    adj: { english: 'adjective', russian: 'прилагательное' },
+    adv: { english: 'adverb', russian: 'наречие' },
+    conj: { english: 'conjunction', russian: 'союз' },
+    det: { english: 'determiner', russian: 'определитель' },
+    intj: { english: 'interjection', russian: 'междометие' },
+    noun: { english: 'noun', russian: 'существительное' },
+    num: { english: 'numeral', russian: 'числительное' },
+    part: { english: 'particle', russian: 'частица' },
+    prep: { english: 'preposition', russian: 'предлог' },
+    pron: { english: 'pronoun', russian: 'местоимение' },
+    verb: { english: 'verb', russian: 'глагол' },
+};
+
+/**
+ * Expands a part of speech abbreviation to its full form in the specified language.
+ * Returns the original abbreviation if no mapping exists.
+ */
+export function expandPos(pos: string, language: QuizLanguage): string {
+    const mapping = posLabels[pos.toLowerCase()];
+    if (!mapping) {
+        return pos;
+    }
+    return mapping[language];
+}

--- a/src/routes/browse/[word]/+page.svelte
+++ b/src/routes/browse/[word]/+page.svelte
@@ -2,18 +2,24 @@
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
 import { page } from '$app/state';
-import { vocabulary } from '$lib/stores/index.js';
-import type { Vocabulary, Word } from '$lib/types.js';
-import { playSound } from '$lib/utils.js';
+import { quizLanguage, vocabulary } from '$lib/stores/index.js';
+import type { QuizLanguage, Vocabulary, Word } from '$lib/types.js';
+import { expandPos, playSound } from '$lib/utils.js';
 
 interface WordWithLevel extends Word {
     level: string;
 }
 
 let vocab = $state<Vocabulary | null>(null);
+let language = $state<QuizLanguage>('english');
 
 $effect(() => {
     const unsub = vocabulary.subscribe((v) => (vocab = v));
+    return unsub;
+});
+
+$effect(() => {
+    const unsub = quizLanguage.subscribe((l) => (language = l));
     return unsub;
 });
 
@@ -51,6 +57,10 @@ function goBackToBrowse() {
         </div>
 
         <div class="word-detail-card">
+            {#if word.pos}
+                <div class="detail-part-of-speech">{expandPos(word.pos, language)}</div>
+            {/if}
+
             <div class="word-main">
                 <span class="detail-armenian-word">{word.am}</span>
                 <button
@@ -88,6 +98,10 @@ function goBackToBrowse() {
                     </ul>
                 </div>
             </div>
+
+            {#if word.etymology_text}
+                <div class="detail-etymology">{word.etymology_text}</div>
+            {/if}
         </div>
     {:else}
         <div class="word-not-found">

--- a/src/routes/learn/[level]/+page.svelte
+++ b/src/routes/learn/[level]/+page.svelte
@@ -19,6 +19,7 @@ import {
 } from '$lib/stores/index.js';
 import type { QuizLanguage, Word } from '$lib/types.js';
 import {
+    expandPos,
     getLanguageLabel,
     getTranslationDisplay,
     playSound,
@@ -144,6 +145,9 @@ function handleKeydown(event: KeyboardEvent) {
 
 	{#if !showComplete && currentWord}
 		<div class="word-card">
+			{#if currentWord.pos}
+				<div class="part-of-speech">{expandPos(currentWord.pos, language)}</div>
+			{/if}
 			<div class="word-header">
 				<div class="armenian-word">{currentWord.am}</div>
 				<button
@@ -160,6 +164,9 @@ function handleKeydown(event: KeyboardEvent) {
 				<div class="pronunciation">{currentWord.spell}</div>
 			{/if}
 			<div class="translation">{translation()} ({languageLabel})</div>
+			{#if currentWord.etymology_text}
+				<div class="etymology">{currentWord.etymology_text}</div>
+			{/if}
 			<div class="word-navigation">
 				<button
 					id="previous-word"


### PR DESCRIPTION
Add "etymology\_text" field value at bottom of "learning" page and "vocabulary" page. Add "pos" value (part of speech, need to expand it from "adj" to "adjective" for English or "прилагательное" for Russian) to the top of "learning" page and "vocabulary" page. Both formatted with italic text.