### PR TITLE
Run lightweight CI checks before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint
+        run: bun run lint:ci
+
+      - name: Unit tests
+        run: bun run test:unit
+
+      - name: Production build
+        run: bun run build
+        env:
+          NODE_ENV: production
+
   deploy:
+    needs: test
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "test": "bunx playwright test",
         "test:unit": "bun test src/",
         "lint": "biome check --write src/",
+        "lint:ci": "biome check src/",
         "lint:fix": "biome check --write src/",
         "vocabulary-build": "python3 scripts/build_vocabulary_v2.py",
         "search-index-build": "bun run scripts/build-search-index.ts"


### PR DESCRIPTION
## Summary
- add a dedicated `test` job in GitHub Actions to run lint, unit tests, and production build checks
- gate the `deploy` job with `needs: test` so deploy runs only after quality checks pass
- add a check-only `lint:ci` script for CI validation without in-place file rewrites

## Test plan
- [x] `bun run lint:ci`
- [x] `bun run test:unit`
- [x] `bun run build`