### PR TITLE
Fix mobile cards-count input with steppers and validation

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -112,14 +112,20 @@ header p {
     font-weight: 600;
 }
 
-.level-btn:hover {
+.level-btn:hover:not(:disabled) {
     border-color: #667eea;
     background: #f7fafc;
     transform: translateY(-2px);
 }
 
-.level-btn:active {
+.level-btn:active:not(:disabled) {
     transform: translateY(0);
+}
+
+.level-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
 }
 
 .settings-row {
@@ -141,6 +147,12 @@ header p {
 .setting-item.horizontal {
     flex-direction: row;
     gap: 0.5rem;
+    align-items: center;
+}
+
+.setting-item.horizontal label {
+    margin-bottom: 0;
+    text-align: left;
     cursor: pointer;
 }
 
@@ -159,8 +171,40 @@ header p {
     text-align: left;
 }
 
+.cards-count-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.cards-count-step {
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
+    background: white;
+    color: #4a5568;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.cards-count-step:hover:not(:disabled) {
+    border-color: #667eea;
+    background: #f7fafc;
+}
+
+.cards-count-step:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .cards-count-input {
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0.5rem;
     border: 2px solid #e2e8f0;
     border-radius: 8px;
     background: white;
@@ -168,8 +212,10 @@ header p {
     font-size: 0.9rem;
     font-weight: 500;
     color: #4a5568;
-    width: 80px;
+    width: 3.5rem;
     text-align: center;
+    -moz-appearance: textfield;
+    appearance: textfield;
 }
 
 .cards-count-input:hover {
@@ -181,6 +227,16 @@ header p {
     outline: none;
     border-color: #667eea;
     box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.cards-count-input.invalid {
+    border-color: #e53e3e;
+    background: #fff5f5;
+}
+
+.cards-count-input.invalid:focus {
+    border-color: #e53e3e;
+    box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.15);
 }
 
 .pos-select {

--- a/src/lib/cardsCount.test.ts
+++ b/src/lib/cardsCount.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { MAX_CARDS_COUNT, MIN_CARDS_COUNT, parseCardsCount } from './cardsCount.js';
+
+describe('parseCardsCount', () => {
+    test('accepts integers in range', () => {
+        expect(parseCardsCount('1')).toBe(MIN_CARDS_COUNT);
+        expect(parseCardsCount('10')).toBe(10);
+        expect(parseCardsCount('100')).toBe(MAX_CARDS_COUNT);
+        expect(parseCardsCount(' 7 ')).toBe(7);
+    });
+
+    test('rejects empty and non-numeric values', () => {
+        expect(parseCardsCount('')).toBeNull();
+        expect(parseCardsCount('   ')).toBeNull();
+        expect(parseCardsCount('abc')).toBeNull();
+        expect(parseCardsCount('1.5')).toBeNull();
+        expect(parseCardsCount('-1')).toBeNull();
+        expect(parseCardsCount('+3')).toBeNull();
+        expect(parseCardsCount('3e1')).toBeNull();
+    });
+
+    test('rejects zero and out-of-range values', () => {
+        expect(parseCardsCount('0')).toBeNull();
+        expect(parseCardsCount('101')).toBeNull();
+        expect(parseCardsCount('999')).toBeNull();
+    });
+
+    test('rejects leading zeros that are not a plain positive integer string path', () => {
+        // "01" is still a valid decimal integer 1
+        expect(parseCardsCount('01')).toBe(1);
+        expect(parseCardsCount('00')).toBeNull();
+    });
+});

--- a/src/lib/cardsCount.ts
+++ b/src/lib/cardsCount.ts
@@ -1,0 +1,11 @@
+export const MIN_CARDS_COUNT = 1;
+export const MAX_CARDS_COUNT = 100;
+
+/** Parse a cards-count draft. Returns null when empty, non-integer, or out of 1–100. */
+export function parseCardsCount(raw: string): number | null {
+    const trimmed = raw.trim();
+    if (!/^\d+$/.test(trimmed)) return null;
+    const n = Number(trimmed);
+    if (n < MIN_CARDS_COUNT || n > MAX_CARDS_COUNT) return null;
+    return n;
+}

--- a/src/lib/i18n/translations/en.ts
+++ b/src/lib/i18n/translations/en.ts
@@ -8,6 +8,8 @@ export const en: Record<string, string> = {
         'App would show given number of words to learn translation of and after this show quiz for translating it back. Your preferences and progress stay saved on this device.',
     'Select Your Armenian Level': 'Select Your Armenian Level',
     'Number of words to learn:': 'Number of words to learn:',
+    'Decrease number of words': 'Decrease number of words',
+    'Increase number of words': 'Increase number of words',
     'Language:': 'Language:',
     'Auto-play pronunciation': 'Auto-play pronunciation',
     'Part of speech:': 'Part of speech:',

--- a/src/lib/i18n/translations/ru.ts
+++ b/src/lib/i18n/translations/ru.ts
@@ -8,6 +8,8 @@ export const ru: Record<string, string> = {
         'Приложение покажет заданное количество слов для изучения перевода, а затем проведёт викторину для проверки. Ваши настройки и прогресс сохраняются на этом устройстве.',
     'Select Your Armenian Level': 'Выберите ваш уровень армянского',
     'Number of words to learn:': 'Количество слов для изучения:',
+    'Decrease number of words': 'Уменьшить количество слов',
+    'Increase number of words': 'Увеличить количество слов',
     'Language:': 'Язык:',
     'Auto-play pronunciation': 'Автоматически проигрывать произношение',
     'Part of speech:': 'Часть речи:',

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,3 +1,4 @@
+export { MAX_CARDS_COUNT, MIN_CARDS_COUNT, parseCardsCount } from '../cardsCount.js';
 export { learntTranslations, userStats } from './progress.js';
 export {
     createQuizQuestions,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,9 @@ import {
     cardsCount,
     getAvailableLevels,
     learntTranslations,
+    MAX_CARDS_COUNT,
+    MIN_CARDS_COUNT,
+    parseCardsCount,
     partOfSpeech,
     userStats,
     vocabulary,
@@ -16,13 +19,23 @@ import {
 import type { PartOfSpeech, Vocabulary } from '$lib/types.js';
 
 let currentCardsCount = $state(10);
+let cardsCountDraft = $state('10');
+let cardsCountDraftTouched = $state(false);
 let currentPartOfSpeech = $state<PartOfSpeech>('all');
 let soundEnabled = $state(true);
 let t = $state((key: string) => key);
 
+const parsedCardsCount = $derived(parseCardsCount(cardsCountDraft));
+const isCardsCountValid = $derived(parsedCardsCount !== null);
+
 // Subscribe to stores
 $effect(() => {
-    const unsubCardsCount = cardsCount.subscribe((v) => (currentCardsCount = v));
+    const unsubCardsCount = cardsCount.subscribe((v) => {
+        currentCardsCount = v;
+        if (!cardsCountDraftTouched) {
+            cardsCountDraft = String(v);
+        }
+    });
     const unsubPos = partOfSpeech.subscribe((v) => (currentPartOfSpeech = v));
     const unsubSound = autoPlaySound.subscribe((v) => (soundEnabled = v));
     const unsubT = tStore.subscribe((v) => (t = v));
@@ -51,6 +64,7 @@ $effect(() => {
 const levels = $derived(getAvailableLevels(vocab));
 
 function selectLevel(level: string) {
+    if (!isCardsCountValid) return;
     goto(`${base}/learn/${level}`);
 }
 
@@ -58,14 +72,20 @@ function toggleSound() {
     autoPlaySound.update((v) => !v);
 }
 
-function handleCardsCountChange(event: Event) {
-    const target = event.target as HTMLInputElement;
-    const value = parseInt(target.value, 10);
-    if (value > 0 && value <= 100) {
-        cardsCount.set(value);
-    } else {
-        target.value = currentCardsCount.toString();
+function handleCardsCountInput() {
+    cardsCountDraftTouched = true;
+    const parsed = parseCardsCount(cardsCountDraft);
+    if (parsed !== null) {
+        cardsCount.set(parsed);
     }
+}
+
+function adjustCardsCount(delta: number) {
+    const current = parsedCardsCount ?? currentCardsCount;
+    const next = Math.min(MAX_CARDS_COUNT, Math.max(MIN_CARDS_COUNT, current + delta));
+    cardsCountDraftTouched = true;
+    cardsCountDraft = String(next);
+    cardsCount.set(next);
 }
 
 function handlePartOfSpeechChange(event: Event) {
@@ -95,7 +115,11 @@ function resetProgress() {
 	<h2>{t('Select Your Armenian Level')}</h2>
 	<div class="level-buttons">
 		{#each levels as level}
-			<button class="level-btn" onclick={() => selectLevel(level)}>
+			<button
+				class="level-btn"
+				disabled={!isCardsCountValid}
+				onclick={() => selectLevel(level)}
+			>
 				{level}
 				{#if LEVEL_DESCRIPTIONS[level]}
 					- {t(LEVEL_DESCRIPTIONS[level])}
@@ -105,19 +129,40 @@ function resetProgress() {
 	</div>
 
 	<div class="settings-row">
-		<label class="setting-item horizontal">
-			<span>{t('Number of words to learn:')}</span>
-			<input
-				type="number"
-				id="cards-count"
-				class="cards-count-input"
-				min="1"
-				max="100"
-				value={currentCardsCount}
-				onchange={handleCardsCountChange}
-				oninput={handleCardsCountChange}
-			/>
-		</label>
+		<div class="setting-item horizontal">
+			<label for="cards-count">{t('Number of words to learn:')}</label>
+			<span class="cards-count-control">
+				<button
+					type="button"
+					class="cards-count-step"
+					aria-label={t('Decrease number of words')}
+					onclick={() => adjustCardsCount(-1)}
+					disabled={parsedCardsCount === MIN_CARDS_COUNT}
+				>
+					−
+				</button>
+				<input
+					type="text"
+					inputmode="numeric"
+					pattern="[0-9]*"
+					id="cards-count"
+					class="cards-count-input"
+					class:invalid={!isCardsCountValid}
+					autocomplete="off"
+					bind:value={cardsCountDraft}
+					oninput={handleCardsCountInput}
+				/>
+				<button
+					type="button"
+					class="cards-count-step"
+					aria-label={t('Increase number of words')}
+					onclick={() => adjustCardsCount(1)}
+					disabled={parsedCardsCount === MAX_CARDS_COUNT}
+				>
+					+
+				</button>
+			</span>
+		</div>
 
 		<div class="setting-item">
 			<label for="part-of-speech">{t('Part of speech:')}</label>


### PR DESCRIPTION
## Summary
- Add −/+ stepper buttons so mobile browsers can change the words-to-learn count without native number-input controls
- Allow empty/invalid draft values in the field (no forced restore), and only persist when the value is an integer from 1–100
- Disable A1–B2 level buttons while the cards count is invalid

## Test plan
- [x] `bun run lint`
- [x] `bun run test:unit`
- [x] `bun run build`
- [ ] On mobile (or narrow viewport): clear the cards field → level buttons disabled; type `3` → enabled
- [ ] Use −/+ steppers to change the count and start a quiz