### PR TITLE
Keep Actions alive so idle-repo merges still deploy

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,41 @@
+# Keep GitHub Actions event triggers alive for low-traffic repos.
+#
+# Public repos with no commits for ~60 days can have Actions event triggers
+# (push / pull_request) suspended. Merges then do not deploy until someone
+# manually re-enables Actions. Calling the workflow "enable" API resets that
+# inactivity timer without creating empty commits.
+name: Keep Actions Alive
+
+on:
+  schedule:
+    # 1st and 15th of each month (UTC) — well under GitHub's ~60-day idle window
+    - cron: "17 5 1,15 * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: keepalive-actions
+  cancel-in-progress: true
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable workflows (reset inactivity timer)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Always touch the deploy workflow so push-to-main deploys stay armed.
+          gh api --method PUT "repos/${{ github.repository }}/actions/workflows/deploy.yml/enable"
+          # Also re-enable anything GitHub marked disabled_inactivity.
+          gh api "repos/${{ github.repository }}/actions/workflows" --paginate \
+            --jq '.workflows[] | select(.state == "disabled_inactivity") | .id' \
+            | while read -r id; do
+                echo "Re-enabling workflow id=${id}"
+                gh api --method PUT "repos/${{ github.repository }}/actions/workflows/${id}/enable"
+              done
+          echo "Keepalive complete."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,12 +201,13 @@ Before submitting changes, verify:
 
 ## Deployment
 
-- **Automatic**: GitHub Actions deploys to GitHub Pages on push to `main` branch
-- **Manual**: Push changes to `main` branch
+- **Automatic**: GitHub Actions deploys to GitHub Pages on push to `main` branch (`deploy.yml`)
+- **Manual deploy**: `gh workflow run deploy.yml --ref main` (or Actions → Deploy → Run workflow)
 - **Build step required**: TypeScript and Sass compilation
 - **Build process**: GitHub Actions installs Bun, runs `bun install`, runs `bun run build`
 - **Deployment source**: Files from `dist/` folder are deployed
-- **Caching**: Browsers cache `vocabulary.json` automatically
+- **Caching**: Browsers cache `vocabulary.json` automatically (HTML/JS assets are hashed)
+- **Idle-repo gotcha**: If `main` has no commits for ~60+ days, GitHub can suspend Actions event triggers. A merge to `main` may then **not** start `deploy.yml` (or only start it much later). `keepalive.yml` re-enables workflows twice a month via API to prevent this. If deploy still did not run after a merge, run the manual deploy command above.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- Root cause of missing deploy after PR #28: ~97 days with no commits on `main`, so GitHub suspended Actions event triggers; the merge push run only appeared after a manual `workflow_dispatch`
- Add `keepalive.yml` (1st/15th of each month + manual) to re-enable workflows via API and reset the inactivity timer without empty commits
- Document the idle-repo gotcha and `gh workflow run deploy.yml` recovery in `AGENTS.md`

## Test plan
- [ ] Confirm `keepalive.yml` appears under Actions
- [ ] Run **Keep Actions Alive** via workflow_dispatch and verify it succeeds
- [ ] Confirm deploy workflow remains active afterward